### PR TITLE
various small improvements

### DIFF
--- a/src/DotNetPad/DotNetPad.Applications/CodeAnalysis/TemplateCode.cs
+++ b/src/DotNetPad/DotNetPad.Applications/CodeAnalysis/TemplateCode.cs
@@ -2,13 +2,25 @@
 {
     internal static class TemplateCode
     {
+        public static string StartCaretIndicator
+        {
+            get
+            {
+                return "@StartCaretPosition@";
+            }
+        }
+
         public static string InitialCSharpCode
         {
             get
             {
                 return
                     @"using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
 
 namespace Sample
 {
@@ -16,14 +28,12 @@ namespace Sample
     {
         internal static void Main()
         {
-            
+            @StartCaretPosition@
         }
     }
 }";
             }
         }
-
-        public static int StartCaretPositionCSharp { get { return 160; } }
 
         public static string InitialVisualBasicCode
         {
@@ -31,18 +41,20 @@ namespace Sample
             {
                 return
                     @"Imports System
+Imports System.Collections.Generic
 Imports System.Linq
+Imports System.Text
+Imports System.Threading.Tasks
+Imports System.IO
 
 Namespace Sample
     Module Program
         Sub Main()
-            
+            @StartCaretPosition@
         End Sub
     End Module
 End Namespace";
             }
         }
-
-        public static int StartCaretPositionVisualBasic { get { return 110; } }
     }
 }

--- a/src/DotNetPad/DotNetPad.Applications/Controllers/FileController.cs
+++ b/src/DotNetPad/DotNetPad.Applications/Controllers/FileController.cs
@@ -304,6 +304,7 @@ namespace Waf.DotNetPad.Applications.Controllers
                 };
 
                 fileService.AddDocument(document);
+                documentCounter++;
             }
 
             if (setActiveDocument) { ActiveDocumentFile = document; }

--- a/src/DotNetPad/DotNetPad.Applications/Controllers/FileController.cs
+++ b/src/DotNetPad/DotNetPad.Applications/Controllers/FileController.cs
@@ -217,7 +217,8 @@ namespace Waf.DotNetPad.Applications.Controllers
             if (string.IsNullOrEmpty(code))
             {
                 code = documentType == DocumentType.CSharp ? TemplateCode.InitialCSharpCode : TemplateCode.InitialVisualBasicCode;
-                startCaretPosition = documentType == DocumentType.CSharp ? TemplateCode.StartCaretPositionCSharp : TemplateCode.StartCaretPositionVisualBasic;
+                startCaretPosition = code.IndexOf(TemplateCode.StartCaretIndicator);
+                code = code.Replace(TemplateCode.StartCaretIndicator, "");
             }
             string fileName = "Script" + (documentCounter + 1) + (documentType == DocumentType.CSharp ? ".cs" : ".vb");
             var document = new DocumentFile(documentType, fileName, code, startCaretPosition);

--- a/src/DotNetPad/DotNetPad.Applications/Controllers/WorkspaceController.cs
+++ b/src/DotNetPad/DotNetPad.Applications/Controllers/WorkspaceController.cs
@@ -268,7 +268,12 @@ namespace Waf.DotNetPad.Applications.Controllers
                     var buildResult = lastBuildResult.Item2;
                     try
                     {
-                        await host.RunScriptAsync(buildResult.InMemoryAssembly, buildResult.InMemorySymbolStore, outputTextWriter, errorTextWriter, cancellationToken);
+                        string documentDirectory = null;
+                        if (Path.IsPathRooted(documentFile.FileName))
+                        {
+                            documentDirectory = Path.GetDirectoryName(documentFile.FileName);
+                        }
+                        await host.RunScriptAsync(buildResult.InMemoryAssembly, buildResult.InMemorySymbolStore, outputTextWriter, errorTextWriter, documentDirectory, cancellationToken);
                     }
                     catch (OperationCanceledException)
                     {


### PR DESCRIPTION
- include previously loaded documents in the documentCounter
- added commonly used using/Import statements to the default template
- set the Directory.GetCurrentDirectory to the same directory as the current script file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jbe2277/dotnetpad/8)
<!-- Reviewable:end -->
